### PR TITLE
Update String.sv

### DIFF
--- a/grammars/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/String.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/String.sv
@@ -143,13 +143,17 @@ top::Expr ::= e::Expr
         
         // Hacky way of testing if a pointer can be dereferenced validly
         // TODO: This isn't remotely thread safe, but I don't know of a better way
-        _set_handler();
-        if (!setjmp(_jump)) {
-          _ptr_val = *_ptr;
+        if(_ptr) {
+          _set_handler();
+          if (!setjmp(_jump)) {
+            _ptr_val = *_ptr;
+          } else {
+            _illegal = 1;
+          }
+          _clear_handler();
         } else {
           _illegal = 1;
         }
-        _clear_handler();
         
         !_illegal?
           "&" + $Expr{


### PR DESCRIPTION
On WebAssembly, `0` is a valid pointer, so `show((string*)NULL)` is `&""`, which is... confusing.